### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
     "humans",
     "parsing"
   ],
-  "author": "Matthew Mueller"
+  "author": "Matthew Mueller",
+  "spm": {
+    "main": "index.js",
+    "dependencies": {
+      "debug": "0.8.1"
+    }
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/date

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of date in spmjs, I can add it for your account after signing in http://spmjs.io.