### PR TITLE
Added repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "humans",
     "parsing"
   ],
+  "repository": "https://github.com/MatthewMueller/date",
   "author": "Matthew Mueller",
   "spm": {
     "main": "index.js",


### PR DESCRIPTION
This will remove the annoying warning from npm

    npm install
    npm WARN package.json date.js@0.2.0 No repository field.
