### PR TITLE
Fix the bug of comparing dates by reference

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -53,7 +53,7 @@ function parser(str, offset) {
   while (this.advance() !== 'eos');
   debug('tokens %j', this.tokens)
   this.nextTime(d);
-  if (this.date.date == d) throw new Error('Invalid date');
+  if (this.date.date - d === 0) throw new Error('Invalid date');
   return this.date.date;
 };
 


### PR DESCRIPTION
The way it was, it would have never thrown, now it should if date format is not recognized.