### PR TITLE
Add no extra day with months in the past

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,7 +22,7 @@ var rMeridiem = /^(\d{1,2})([:.](\d{1,2}))?([:.](\d{1,2}))?\s*([ap]m)/;
 var rHourMinute = /^(\d{1,2})([:.](\d{1,2}))([:.](\d{1,2}))?/;
 var rAtHour = /^at\s?(\d{1,2})$/;
 var rDays = /\b(sun(day)?|mon(day)?|tues(day)?|wed(nesday)?|thur(sday|s)?|fri(day)?|sat(urday)?)s?\b/;
-var rMonths = /^((\d{1,2})(st|nd|rd|th))\sof\s(january|february|march|april|may|june|july|august|september|october|november|december)/;
+var rMonths = /^((\d{1,2})(st|nd|rd|th))\sof\s(january|february|march|april|may|june|july|august|september|october|november|december)/i;
 var rPast = /\b(last|yesterday|ago)\b/;
 var rDayMod = /\b(morning|noon|afternoon|night|evening|midnight)\b/;
 var rAgo = /^(\d*)\s?\b(second|minute|hour|day|week|month|year)[s]?\b\s?ago$/;
@@ -255,7 +255,7 @@ parser.prototype.monthByName = function() {
     var day = captures[2]
     var month = captures[4];
     this.date.date.setMonth((months.indexOf(month)));
-    if (day) this.date.date.setDate(parseInt(day) - 1);
+    if (day) this.date.date.setDate(parseInt(day));
     this.skip(captures);
     return captures[0];
   }
@@ -382,8 +382,16 @@ parser.prototype.nextTime = function(before) {
   if (before <= d.date || rPast.test(orig)) return this;
 
   // If time is in the past, we need to guess at the next time
-  if (rDays.test(orig)) d.day(7);
-  else if ((before - d.date) / 1000 > 60) d.day(1);
+  if (rDays.test(orig)) {
+    d.day(7);
+  } else if ((before - d.date) / 1000 > 60) {
+    // If it is a month in the past, don't add a day
+    if (rMonths.test(orig)) {
+      d.day(0);
+    } else {
+      d.day(1);
+    }
+  }
 
   return this;
 };

--- a/test/parser.js
+++ b/test/parser.js
@@ -663,13 +663,19 @@ describe('months (fixes: #10)', function (){
     var date = parse('31st of September 4:00am', after);
     assert('4:00:00' == t(date));
     assert('9/31/13' != d(date));
-    assert('9/30/13' == d(date));
+    assert('10/1/13' == d(date));
   });
 
   it('1st of January 4:00am', function(){
     var date = parse('1st of January 4:00am', after);
     assert('4:00:00' == t(date));
     assert('1/1/13' == d(date));
+  })
+
+  it('9th of December 4:00am', function(){
+    var date = parse('9th of December 4:00am', after);
+    assert('4:00:00' == t(date));
+    assert('12/9/13' == d(date));
   })
 });
 


### PR DESCRIPTION
**Context**: 
When trying to parse a future date with a month, like today is "20th of November" and the future date being parsed is "9th of December". The returned date from `date.js` would be off by one, i.e. a Date object for the 8th of December. 

**Solution:**
I added a test for '9th of December 4:00am' and got the same bug I was running into in my own app. To fix this issue, I modified `parser.nextTime` to look for a match with the `rMonths` regex and not add a day to the date. 

I hope this makes sense. I appreciate all the work that went into making this awesome library. Thanks for considering this PR. 