### PR TITLE
Correct the carryUp for days of the month

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -24,7 +24,7 @@ for (var i = 0; i < timeUnitOrder.length; i++) {
   canonTimeUnitOrder.push(lemma(unit).canon)
 }
 var tOrdering = ['y', 'M', 'd', 'h', 'm', 's']
-var tFactor = [365, 30, 24, 60, 60]
+var tFactor = [365, 31, 24, 60, 60]
 
 /**
  * Delimiters for stdT string

--- a/test/parser.js
+++ b/test/parser.js
@@ -683,6 +683,12 @@ describe('bug fixes', function() {
     assert('9:00:00' == t(date));
     assert('5/14/13' == d(date));
   })
+
+  it('2017-04-30 (correct carry up)', function () {
+      var date = parse('2017-04-30', mon);
+      assert('4/30/17' == d(date));
+  });
+
 });
 
 /**


### PR DESCRIPTION
The carry up currently causes the dates like "2017-04-30" to result in "Invalid date", while other dates like "2017-04-29" all the way down to "2017-04-1" yield the right result.
