### PR TITLE
docs: Fix simple typo, proprocessed -> preprocessed

### DIFF
--- a/dist/date.js
+++ b/dist/date.js
@@ -1255,7 +1255,7 @@ function parser (str, offset) {
   // console.log(prepro)
   // reset the str to prepro str
   str = prepro.str
-  // if proprocessed doesn't leave any str to be processed (non-date-time) format, check normals
+  // if preprocessed doesn't leave any str to be processed (non-date-time) format, check normals
   if (!str) {
     if (prepro.normals.length) {
       // if there's normal date parsed already,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -54,7 +54,7 @@ function parser (str, offset) {
   // console.log(prepro)
   // reset the str to prepro str
   str = prepro.str
-  // if proprocessed doesn't leave any str to be processed (non-date-time) format, check normals
+  // if preprocessed doesn't leave any str to be processed (non-date-time) format, check normals
   if (!str) {
     if (prepro.normals.length) {
       // if there's normal date parsed already,


### PR DESCRIPTION
There is a small typo in dist/date.js, lib/parser.js.

Should read `preprocessed` rather than `proprocessed`.

